### PR TITLE
Updated link to Elexon API doc

### DIFF
--- a/docs/pywind.elexon.rst
+++ b/docs/pywind.elexon.rst
@@ -8,7 +8,7 @@
 .. warning::
   Use of the Elexon API requires registration and use of an API key. Registration is free.
 
-Details of the Elexon API can be found in https://www.elexon.co.uk/wp-content/uploads/2016/10/Application-Programming-Interfaces-API-and-Data-Push-user-guide.pdf
+Details of the Elexon API can be found in https://www.elexon.co.uk/documents/training-guidance/bsc-guidance-notes/bmrs-api-and-data-push-user-guide-2/
 
 
 :mod:`pywind.elexon.api`

--- a/pywind/elexon/api.py
+++ b/pywind/elexon/api.py
@@ -1,6 +1,6 @@
 """ Information taken from the Elexon API User Guide.
 
-https://www.elexon.co.uk/wp-content/uploads/2016/10/Application-Programming-Interfaces-API-and-Data-Push-user-guide.pdf
+https://www.elexon.co.uk/documents/training-guidance/bsc-guidance-notes/bmrs-api-and-data-push-user-guide-2/
 
 """
 from datetime import datetime


### PR DESCRIPTION
The [original link](https://www.elexon.co.uk/wp-content/uploads/2016/10/Application-Programming-Interfaces-API-and-Data-Push-user-guide.pdf) in pywind's documentation does not work anymore.